### PR TITLE
Add ability to use ranger as file-chooser in gvim

### DIFF
--- a/autoload/ranger.vim
+++ b/autoload/ranger.vim
@@ -3,7 +3,11 @@ function! ranger#launch()
     " The option "--choosefiles" was added in ranger 1.5.1. Use the next line
     " with ranger 1.4.2 through 1.5.0 instead.
     "exec 'silent !ranger --choosefile=' . shellescape(temp)
-    exec 'silent !ranger --choosefiles=' . shellescape(temp)
+    if has("gui_running")
+        exec 'silent !xterm -e ranger --choosefiles=' . shellescape(temp)
+    else
+        exec 'silent !ranger --choosefiles=' . shellescape(temp)
+    endif
     if !filereadable(temp)
         redraw!
         " Nothing to read.


### PR DESCRIPTION
Previously RangeChooser() would just fail silently in gvim. With this change, it will open an xterm and open ranger there. Everything else works as before.

Of course, you'd need to remove the check you have in plugin/ranger.vim.

I've also proposed this minor change at https://github.com/hut/ranger/pull/353 which is your source, but since you've gone to the trouble of putting this up I thought I'd notify you too.